### PR TITLE
Migrate data fetching to API routes with no-store caching

### DIFF
--- a/app/api/v2/assignments/route.ts
+++ b/app/api/v2/assignments/route.ts
@@ -37,6 +37,9 @@ export async function GET(req: NextRequest) {
 			const allQuiz = (await getAllAssignments()) as AssignmentData[];
 			return NextResponse.json(allQuiz);
 		}
+	} else {
+		const allQuiz = (await getAllAssignments()) as AssignmentData[];
+		return NextResponse.json(allQuiz);
 	}
 }
 

--- a/app/api/v2/quiz/route.ts
+++ b/app/api/v2/quiz/route.ts
@@ -39,6 +39,9 @@ export async function GET(req: NextRequest) {
 			const allQuiz = (await getAllQuiz()) as QuizData[];
 			return NextResponse.json(allQuiz);
 		}
+	} else {
+		const allQuiz = (await getAllQuiz()) as QuizData[];
+		return NextResponse.json(allQuiz);
 	}
 }
 

--- a/app/api/v2/students/[id]/route.ts
+++ b/app/api/v2/students/[id]/route.ts
@@ -7,6 +7,13 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
 		where: {
 			id: parseInt(id),
 		},
+		include: {
+			StudentHistory: {
+				orderBy: {
+					academicYear: "desc",
+				},
+			},
+		},
 	});
 	return NextResponse.json(studentData);
 }

--- a/app/api/v2/students/route.ts
+++ b/app/api/v2/students/route.ts
@@ -42,10 +42,10 @@ export async function GET(req: NextRequest) {
 			)) as StudentData;
 			return NextResponse.json(studentData);
 		}
+	} else {
+		const allStudent = await getAllStudents();
+		return NextResponse.json(allStudent);
 	}
-
-	const allStudent = await getAllStudents();
-	return NextResponse.json(allStudent);
 }
 
 export async function POST(req: NextRequest) {

--- a/app/api/v2/users/[id]/route.ts
+++ b/app/api/v2/users/[id]/route.ts
@@ -7,6 +7,9 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
 		where: {
 			id,
 		},
+		include: {
+			student: {},
+		},
 	});
 	return NextResponse.json(userData);
 }

--- a/app/assignments/page.tsx
+++ b/app/assignments/page.tsx
@@ -2,10 +2,19 @@ import React from "react";
 import { AssignmentData } from "@/types/types";
 import { columns } from "./columns";
 import { DataTable } from "./DataTable";
-import { getAllAssignments } from "@/lib/server/actions";
+
+async function getData(): Promise<AssignmentData[]> {
+	const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v2/assignments`, {
+		cache: "no-store",
+	});
+
+	const allAssignmentData: AssignmentData[] = await response.json();
+
+	return allAssignmentData;
+}
 
 const page = async () => {
-	const data = (await getAllAssignments()) as AssignmentData[];
+	const data = await getData();
 	return <DataTable columns={columns} data={data} />;
 };
 

--- a/app/documents/page.tsx
+++ b/app/documents/page.tsx
@@ -1,6 +1,5 @@
 import DocumentForm from "@/components/layouts/forms/DocumentForm";
 import DocumentCard from "@/components/layouts/DocumentCard";
-import { getAllDocuments } from "@/lib/server/actions";
 import { DocumentData } from "@/types/types";
 import {
 	Dialog,
@@ -16,8 +15,18 @@ import { Separator } from "@/components/ui/separator";
 
 export const revalidate = 60;
 
+async function getData(): Promise<DocumentData[]> {
+	const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v2/documents`, {
+		cache: "no-store",
+	});
+
+	const allDocumentData: DocumentData[] = await response.json();
+
+	return allDocumentData;
+}
+
 export default async function page() {
-	const data = (await getAllDocuments()) as DocumentData[];
+	const docs = await getData();
 	return (
 		<div>
 			<div className='mb-4'>
@@ -34,7 +43,7 @@ export default async function page() {
 			</div>
 			<Separator />
 			<div className='grid sm:grid-cols-1 md:grid-cols-2 gap-4 mt-4'>
-				{data.map((doc) => (
+				{docs.map((doc) => (
 					<DocumentCard key={doc.id} title={doc.title} fileUrl={doc.fileUrl} authorId={doc.authorId} />
 				))}
 			</div>

--- a/app/quiz/page.tsx
+++ b/app/quiz/page.tsx
@@ -2,10 +2,19 @@ import React from "react";
 import { QuizData } from "@/types/types";
 import { columns } from "./columns";
 import { DataTable } from "./DataTable";
-import { getAllQuiz } from "@/lib/server/actions";
+
+async function getData(): Promise<QuizData[]> {
+	const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v2/quiz`, {
+		cache: "no-store",
+	});
+
+	const allQuizData: QuizData[] = await response.json();
+
+	return allQuizData;
+}
 
 const page = async () => {
-	const data = (await getAllQuiz()) as QuizData[];
+	const data = await getData();
 	return <DataTable columns={columns} data={data} />;
 };
 

--- a/app/students/[id]/page.tsx
+++ b/app/students/[id]/page.tsx
@@ -14,11 +14,23 @@ import {
 	PaginationNext,
 	PaginationPrevious,
 } from "@/components/ui/pagination";
+import { StudentData, UserData } from "@/types/types";
+
+async function getStudentData(studentId: number): Promise<StudentData> {
+	const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v2/students/${studentId}`, {
+		cache: "no-store",
+	});
+
+	const studentData: StudentData = await response.json();
+
+	console.log(studentData);
+
+	return studentData;
+}
 
 const page = async ({ params }: { params: { id: string } }) => {
 	const { id } = params;
-	const student = await Student(parseInt(id));
-	const studentHistory = await findHistoryByStudent(parseInt(id));
+	const student = await getStudentData(parseInt(id));
 	return (
 		<div>
 			<Pagination className='text-left'>
@@ -112,8 +124,8 @@ const page = async ({ params }: { params: { id: string } }) => {
 									</TableRow>
 								</TableHeader>
 								<TableBody>
-									{studentHistory ? (
-										studentHistory.map((history) => (
+									{student.StudentHistory ? (
+										student.StudentHistory.map((history) => (
 											<TableRow key={history.id}>
 												<TableCell>{history.academicYear}年度</TableCell>
 												<TableCell>{history.grade}年</TableCell>

--- a/app/students/page.tsx
+++ b/app/students/page.tsx
@@ -1,11 +1,21 @@
 import React from "react";
-import { StudentData } from "@/types/types";
+import { DocumentData, StudentData } from "@/types/types";
 import { columns } from "./columns";
 import { DataTable } from "./DataTable";
 import { getAllStudents } from "@/lib/server/actions";
 
+async function getData(): Promise<StudentData[]> {
+	const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v2/students`, {
+		cache: "no-store",
+	});
+
+	const allStudentData: StudentData[] = await response.json();
+
+	return allStudentData;
+}
+
 const page = async () => {
-	const data = (await getAllStudents()) as StudentData[];
+	const data = await getData();
 	return <DataTable columns={columns} data={data} />;
 };
 

--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -15,18 +15,23 @@ import {
 	PaginationPrevious,
 } from "@/components/ui/pagination";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { StudentData, UserData } from "@/types/types";
+
+async function getUserData(userId: string): Promise<UserData> {
+	const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v2/users/${userId}`, {
+		cache: "no-store",
+	});
+
+	const userData: UserData = await response.json();
+
+	console.log(userData);
+
+	return userData;
+}
 
 const page = async ({ params }: { params: { id: string } }) => {
 	const { id } = params;
-	const user = await User(id);
-	let student = null;
-	if (user.studentId && user.isLinked) {
-		try {
-			student = await Student(user.studentId);
-		} catch (error) {
-			console.error("Failed to fetch student data:", error);
-		}
-	}
+	const user = await getUserData(id);
 	return (
 		<div>
 			<Pagination className='text-left'>
@@ -91,23 +96,23 @@ const page = async ({ params }: { params: { id: string } }) => {
 							<div className='text-sm font-medium text-gray-500'>連携状態</div>
 							<div>{user.isLinked ? "連携済" : "未連携"}</div>
 						</div>
-						{student && (
+						{user.student && (
 							<div className='mt-4 grid grid-cols-2 gap-2'>
 								<div>
 									<div className='text-sm font-medium text-gray-500'>入学年度</div>
-									<div>{student.enrollmentYear}年度</div>
+									<div>{user.student.enrollmentYear}年度</div>
 								</div>
 								<div>
 									<div className='text-sm font-medium text-gray-500'>現在の学年</div>
-									<div>{student.currentGrade}年</div>
+									<div>{user.student.currentGrade}年</div>
 								</div>
 								<div>
 									<div className='text-sm font-medium text-gray-500'>クラス</div>
-									<div>{student.currentClass}組</div>
+									<div>{user.student.currentClass}組</div>
 								</div>
 								<div>
 									<div className='text-sm font-medium text-gray-500'>出席番号</div>
-									<div>{student.currentNumber}番</div>
+									<div>{user.student.currentNumber}番</div>
 								</div>
 							</div>
 						)}

--- a/app/users/page.tsx
+++ b/app/users/page.tsx
@@ -4,8 +4,18 @@ import { columns } from "./columns";
 import { DataTable } from "./DataTable";
 import { getAllUsers } from "@/lib/server/actions";
 
+async function getData(): Promise<UserData[]> {
+	const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v2/users`, {
+		cache: "no-store",
+	});
+
+	const allUserData: UserData[] = await response.json();
+
+	return allUserData;
+}
+
 const page = async () => {
-	const data = (await getAllUsers()) as UserData[];
+	const data = await getData();
 	return <DataTable columns={columns} data={data} />;
 };
 

--- a/components/layouts/Feed.tsx
+++ b/components/layouts/Feed.tsx
@@ -18,10 +18,18 @@ const getTypeIcon = (type: string) => {
 	}
 };
 
-export const revalidate = 60;
+async function getData(): Promise<PostData[]> {
+	const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/v2/posts`, {
+		cache: "no-store",
+	});
+
+	const allPostData: PostData[] = await response.json();
+
+	return allPostData;
+}
 
 export default async function Feed() {
-	const posts = (await getAllPosts()) as PostData[];
+	const posts = await getData();
 
 	if (!posts) return <div>ポストはありません...</div>;
 	return (

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,6 +71,8 @@ model StudentHistory {
 
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt
+
+    @@index([studentId])
 }
 
 model Assignment {

--- a/types/types.ts
+++ b/types/types.ts
@@ -15,6 +15,7 @@ export interface UserData {
 	isAvailable: boolean;
 	createdAt: Date;
 	updatedAt: Date;
+	student: StudentData;
 	Assignment: AssignmentData[];
 	Quiz: QuizData[];
 	Change: ChangeData[];


### PR DESCRIPTION
- Replaced direct Prisma calls with fetch requests to v2 API routes
- Added getData() functions in pages to fetch data from new API endpoints
- Configured fetch with no-store cache to ensure fresh data
- Updated student and user detail pages to use new data fetching method
- Added include options in API routes for related data (StudentHistory, student)
- Added Prisma schema index for StudentHistory table
- Updated types to include nested data relationships